### PR TITLE
refactor: remove snap extension env-injector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SNAP_SOURCES := $(shell find snap/ -type f)
 ##@ Snap
 
 $(OVN_EXPORTER_SNAP): $(OVN_EXPORTER_SOURCES) $(SNAP_SOURCES) ## Build the application snap
-		SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft pack -o $(OVN_EXPORTER_SNAP)
+		snapcraft pack -o $(OVN_EXPORTER_SNAP)
 
 build: $(OVN_EXPORTER_SNAP) ## Build the application snap
 
@@ -62,7 +62,7 @@ test-coverage: ## Run tests with coverage report
 mocks: ## Generate mock files using mockery
 		mockery
 
-$(ALL_TESTS): go-build
+$(ALL_TESTS): build
 	echo "Running functional test $@";  \
 	$(CURDIR)/microovn/.bats/bats-core/bin/bats $@
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,32 +2,37 @@
 
 set -e
 
-# Check if any OVN-related environment variables have been configured
-ovn_env_changed=false
+# Configuration hook for ovn-exporter snap
+# This hook validates configuration options and restarts the service when needed
 
-# List of OVN environment variables to monitor
-ovn_env_vars=(
-	"apps.ovn-exporter.env.ovn-rundir"
-	"apps.ovn-exporter.env.ovs-rundir"
-	"apps.ovn-exporter.env.ovs-vswitchd-pid"
-	"apps.ovn-exporter.env.ovsdb-server-pid"
-	"apps.ovn-exporter.env.ovn-nbdb-location"
-	"apps.ovn-exporter.env.ovn-sbdb-location"
+# List of supported configuration options
+config_options=(
+	"ovn-rundir"
+	"ovs-rundir"
+	"ovs-vswitchd-pid"
+	"ovsdb-server-pid"
+	"ovn-nbdb-location"
+	"ovn-sbdb-location"
 )
 
-# Check if any of the OVN environment variables are set
-for env_var in "${ovn_env_vars[@]}"; do
-	if snapctl get "$env_var" >/dev/null 2>&1; then
-		echo "OVN environment variable $env_var is configured"
-		ovn_env_changed=true
+# Flag to track if any configuration changed
+config_changed=false
+
+# Validate and set default values if needed
+for option in "${config_options[@]}"; do
+	# Get current value
+	current_value=$(snapctl get "$option" 2>/dev/null || echo "")
+
+	if [[ -n $current_value ]]; then
+		config_changed=true
 		break
 	fi
 done
 
-# Restart service if any OVN environment variables are configured
-if [[ $ovn_env_changed == "true" ]]; then
-	echo "OVN environment variables detected, restarting ovn-exporter service"
-	snapctl restart ovn-exporter.ovn-exporter || echo "Service restart failed, continuing..."
+# Restart service if any configuration changed
+if [[ $config_changed == "true" ]]; then
+	echo "Configuration changes detected, restarting ovn-exporter service"
+	snapctl restart ovn-exporter.ovn-exporter 2>/dev/null || echo "Service restart scheduled"
 else
-	echo "No OVN environment variables configured"
+	echo "No configuration changes detected"
 fi

--- a/snap/hooks/connect-plug-ovn-central-data
+++ b/snap/hooks/connect-plug-ovn-central-data
@@ -2,8 +2,8 @@
 set -e
 
 # Set OVN database locations when ovn-central-data interface is connected
-snapctl set "apps.ovn-exporter.env.ovn-nbdb-location"="$SNAP_COMMON/data/central/db/ovnnb_db.db"
-snapctl set "apps.ovn-exporter.env.ovn-sbdb-location"="$SNAP_COMMON/data/central/db/ovnsb_db.db"
+snapctl set "ovn-nbdb-location"="$SNAP_COMMON/data/central/db/ovnnb_db.db"
+snapctl set "ovn-sbdb-location"="$SNAP_COMMON/data/central/db/ovnsb_db.db"
 echo "Set OVN database locations in $SNAP_COMMON/data/central/db/"
 
 # Restart the service to pick up new environment (ignore errors)

--- a/snap/hooks/connect-plug-ovn-chassis
+++ b/snap/hooks/connect-plug-ovn-chassis
@@ -3,10 +3,10 @@ set -e
 
 # Set OVS and OVN run directories when ovn-chassis interface is connected
 # Note: ovn-chassis now provides both switch and ovn runtime directories
-snapctl set "apps.ovn-exporter.env.ovs-rundir"="$SNAP_COMMON/run/switch"
-snapctl set "apps.ovn-exporter.env.ovs-vswitchd-pid"="$SNAP_COMMON/run/switch/ovs-vswitchd.pid"
-snapctl set "apps.ovn-exporter.env.ovsdb-server-pid"="$SNAP_COMMON/run/switch/ovsdb-server.pid"
-snapctl set "apps.ovn-exporter.env.ovn-rundir"="$SNAP_COMMON/run/ovn"
+snapctl set "ovs-rundir"="$SNAP_COMMON/run/switch"
+snapctl set "ovs-vswitchd-pid"="$SNAP_COMMON/run/switch/ovs-vswitchd.pid"
+snapctl set "ovsdb-server-pid"="$SNAP_COMMON/run/switch/ovsdb-server.pid"
+snapctl set "ovn-rundir"="$SNAP_COMMON/run/ovn"
 echo "Set OVS_RUNDIR to $SNAP_COMMON/run/switch and OVN_RUNDIR to $SNAP_COMMON/run/ovn"
 
 # Restart the service to pick up new environment (ignore errors)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,8 +36,6 @@ apps:
     command: bin/ovnexporter-wrapper
     daemon: simple
     restart-condition: always
-    extensions:
-      - env-injector
     environment:
       PATH: "$SNAP/bin:$PATH"
     plugs:

--- a/snap/wrappers/ovnexporter-wrapper
+++ b/snap/wrappers/ovnexporter-wrapper
@@ -4,27 +4,27 @@ export PATH="$SNAP/bin:$SNAP_COMMON/ovn-commands/bin:$PATH"
 export LD_LIBRARY_PATH="$SNAP_COMMON/ovn-commands/lib:$SNAP_COMMON/ovn-commands/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
 
 # Export environment variables from snap configuration
-if OVN_RUNDIR=$(snapctl get apps.ovn-exporter.env.ovn-rundir 2>/dev/null); then
+if OVN_RUNDIR=$(snapctl get ovn-rundir 2>/dev/null); then
 	export OVN_RUNDIR
 fi
 
-if OVS_RUNDIR=$(snapctl get apps.ovn-exporter.env.ovs-rundir 2>/dev/null); then
+if OVS_RUNDIR=$(snapctl get ovs-rundir 2>/dev/null); then
 	export OVS_RUNDIR
 fi
 
-if OVS_VSWITCHD_PID=$(snapctl get apps.ovn-exporter.env.ovs-vswitchd-pid 2>/dev/null); then
+if OVS_VSWITCHD_PID=$(snapctl get ovs-vswitchd-pid 2>/dev/null); then
 	export OVS_VSWITCHD_PID
 fi
 
-if OVSDB_SERVER_PID=$(snapctl get apps.ovn-exporter.env.ovsdb-server-pid 2>/dev/null); then
+if OVSDB_SERVER_PID=$(snapctl get ovsdb-server-pid 2>/dev/null); then
 	export OVSDB_SERVER_PID
 fi
 
-if OVN_NBDB_LOCATION=$(snapctl get apps.ovn-exporter.env.ovn-nbdb-location 2>/dev/null); then
+if OVN_NBDB_LOCATION=$(snapctl get ovn-nbdb-location 2>/dev/null); then
 	export OVN_NBDB_LOCATION
 fi
 
-if OVN_SBDB_LOCATION=$(snapctl get apps.ovn-exporter.env.ovn-sbdb-location 2>/dev/null); then
+if OVN_SBDB_LOCATION=$(snapctl get ovn-sbdb-location 2>/dev/null); then
 	export OVN_SBDB_LOCATION
 fi
 


### PR DESCRIPTION
ovn-exporter rely on launchpad to automatically build & release snap. But launchpad currently doesn't support experimental extension.