### PR TITLE
gitignore: Snap artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ovnexporter
+*.snap


### PR DESCRIPTION
Ignore ovn-exporter snap produced by `make build` target.