### PR TITLE
github: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @canonical/ovn-team


### PR DESCRIPTION
When CODEOWNERS file [0] is present, people and teams listed in the file are automatically added as reviewers for open PRs. It also enables us to require review specifically from code owners before a PR is merged.

[0] https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners